### PR TITLE
add php 5 support

### DIFF
--- a/src/Recurrence.php
+++ b/src/Recurrence.php
@@ -88,7 +88,7 @@ class Recurrence {
      * Set the frequency for Rrule
      * @param Array $requested Requested frequency
      */
-    public function setFrequency(string $requested) {
+    public function setFrequency($requested) {
         $requested = strtoupper($requested);
         $this->requestedFrequency = "FREQ={$requested};";
         return $this;
@@ -106,7 +106,7 @@ class Recurrence {
      * Set the count value for Rrule
      * @param int $count The count
      */
-    public function setCount(int $count) {
+    public function setCount($count) {
         $this->requestedCount = "COUNT={$count};";
 
         return $this;
@@ -124,7 +124,7 @@ class Recurrence {
      * Set the interval value for Rrule
      * @param int $interval The interval
      */
-    public function setInterval(int $interval) {
+    public function setInterval($interval) {
         $this->requestedInterval = "INTERVAL={$interval};";
 
         return $this;


### PR DESCRIPTION
remove type hintings of string, int ... which is only supported since php 7.0

I need the `Recurrence` class for my project but the production server runs only php 5.6.
With this line `"php": "~5.6|~7.0",` in your dependency list you say this package supports php 5.6 but that will doesn't work because typehints of base types are only supported since php 7.0.

(now the tests run on `5.6` and `7.0`)
